### PR TITLE
Right side garden fix on small screens

### DIFF
--- a/components/HarvestCalculator.vue
+++ b/components/HarvestCalculator.vue
@@ -103,14 +103,14 @@ watchEffect(() => {
 
 <template>
   <section
-    class="transition-all lg:max-w-2xl lg:h-fit rounded-none z-50 overflow-visible w-full xl:max-w-3xl"
+    class="transition-all lg:max-w-2xl lg:h-fit rounded-none z-50 overflow-visible w-full xl:max-w-3xl pointer-events-none"
     :class="[
       gardenTilesAreWide ? '!max-w-none px-0' : 'lg:pl-20 xl:pl-2 xl:px-4 lg:px-2',
       isTakingScreenshot.get && !gardenTilesAreWide ? 'max-w-[46rem] px-4' : '',
     ]"
   >
     <div
-      class="bg-primary flex flex-col"
+      class="bg-primary flex flex-col pointer-events-auto"
       :class="[
         isTakingScreenshot.get ? 'rounded-lg' : 'pt-2 md:pt-0 pb-6 lg:pb-0',
         gardenTilesAreWide ? 'rounded-none' : 'lg:rounded-lg ',


### PR DESCRIPTION
~ Fixed an issue where the harvest approximator was blocking interactions with the right side of the garden due to DOM order